### PR TITLE
fix: detect npm link global install in isPackagedCliEntry via realpathSync

### DIFF
--- a/src/cli/paths.ts
+++ b/src/cli/paths.ts
@@ -14,7 +14,7 @@
  * 模块加载时会调用 `applyRuntimeDataEnvDefaults()`，保证 Web/CLI 子模块读到一致路径。
  */
 
-import { promises as fs } from 'node:fs';
+import { promises as fs, realpathSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -37,8 +37,18 @@ export function isProductionRuntime(): boolean {
 
 /** 从 `npm install -g` / tgz 安装的 `iceCoder` CLI 入口（含 npm link 到包目录）。 */
 export function isPackagedCliEntry(): boolean {
-  const entry = (process.argv[1] ?? '').replace(/\\/g, '/');
-  return entry.includes('/node_modules/ice-coder/dist/cli/');
+  const raw = process.argv[1] ?? '';
+  if (!raw) return false;
+  // 解析 symlink（npm install -g / npm link 的 bin 是 symlink）
+  let resolved: string;
+  try {
+    resolved = realpathSync(raw);
+  } catch {
+    resolved = raw;
+  }
+  const entry = resolved.replace(/\\/g, '/');
+  return entry.includes('/node_modules/ice-coder/dist/cli/')
+    || entry.endsWith('/dist/cli/index.js');
 }
 
 /** Electron 打包应用内嵌 server（由主进程设置 ICE_ELECTRON=1）。 */


### PR DESCRIPTION
## Problem

`isPackagedCliEntry()` only checks if `process.argv[1]` contains `/node_modules/ice-coder/dist/cli/`. When installed via `npm link` or `npm install -g .` from a local checkout, the bin symlink resolves back to the repo's `dist/cli/index.js`, which doesn't match this pattern. As a result, the runtime falls back to dev mode (`./data/` instead of `~/.iceCoder/`).

## Fix

Use `fs.realpathSync()` to resolve the symlink before checking the path pattern. Also accept paths ending with `/dist/cli/index.js` to cover local installs.

## Testing

- `npm link` + `iceCoder config` now correctly reads `~/.iceCoder/config.json` instead of `./data/config.json`
- Global install via `npm install -g` continues to work unchanged